### PR TITLE
Apply z-index style setting to the div that wraps the image

### DIFF
--- a/Leaflet.ImageOverlay.Rotated.js
+++ b/Leaflet.ImageOverlay.Rotated.js
@@ -88,6 +88,8 @@ L.ImageOverlay.Rotated = L.ImageOverlay.extend({
 		var div = this._image = L.DomUtil.create('div',
 				'leaflet-image-layer ' + (this._zoomAnimated ? 'leaflet-zoom-animated' : ''));
 
+		this._updateZIndex(); // apply z-index style setting to the div (if defined)
+		
 		div.appendChild(img);
 
 		div.onselectstart = L.Util.falseFn;


### PR DESCRIPTION
Fixes #8 

The _updateZIndex() method from the base class checks whether this.options.zIndex is defined and has a value, so no other check is required here.