### PR TITLE
Add guard clause for _resets with no map

### DIFF
--- a/Leaflet.ImageOverlay.Rotated.js
+++ b/Leaflet.ImageOverlay.Rotated.js
@@ -108,6 +108,10 @@ L.ImageOverlay.Rotated = L.ImageOverlay.extend({
 	_reset: function () {
 		var div = this._image;
 
+		if (!this._map) {
+			return;
+		}
+
 		// Project control points to container-pixel coordinates
 		var pxTopLeft    = this._map.latLngToLayerPoint(this._topLeft);
 		var pxTopRight   = this._map.latLngToLayerPoint(this._topRight);


### PR DESCRIPTION
So, I have been encountering some issues where _reset is called when this._map in not instantiated.

I am proposing a guard clause which will prevent doing resets on maps that doesn't exist yet. 
This seems to be an issue with chrome when loading leaflet and might be better suited to be fixed there. 

I have tested on other standard browsers and this guard clause is working for any browser. 

Adding this PR as a proposal. If this is unwanted, feel free to close it. 

@IvanSanchez hoping to hear fro you! (I will definitely get you that 🍺 if we one day bump into eachother)