### PR TITLE
Fix Image Loading bug on Internet Explorer 11

### DIFF
--- a/Leaflet.ImageOverlay.Rotated.js
+++ b/Leaflet.ImageOverlay.Rotated.js
@@ -56,9 +56,6 @@ L.ImageOverlay.Rotated = L.ImageOverlay.extend({
 		}
 
 		map.on('zoomend resetview', this._reset, this);
-
-		this.getPane().appendChild(this._image);
-		this._reset();
 	},
 
 
@@ -96,8 +93,9 @@ L.ImageOverlay.Rotated = L.ImageOverlay.extend({
 		div.onmousemove = L.Util.falseFn;
 
 		img.onload = function(){
-			this._reset();
+			this.getPane().appendChild(this._image);
 			img.style.display = 'block';
+			this._reset();
 			this.fire('load');
 		}.bind(this);
 


### PR DESCRIPTION
When using this plug-in on IE 11, the images are loaded on the wrong location without rotation. The reason was `0` image width and height values inside the `_reset` function. To fix this, I moved the append image statement to `img.onload` method and removed unnecessary `_reset` call inside `onAdd`. This fixes the Internet Explorer bug